### PR TITLE
Timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ kafkabeat:
   # Defaults to "json".
   codec: "json"
 
+  # Timestamp key used by JSON decoder
+  #timestamp_key: "@timestamp"
+
+  # Timestamp layout used by JSON decoder
+  #timestamp_layout: "2006-01-02T15:04:05.000Z"
+
   # Event publish mode: "default", "send" or "drop_if_full".
   # Defaults to "default"
   # @see https://github.com/elastic/beats/blob/v6.3.1/libbeat/beat/pipeline.go#L119

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ kafkabeat:
 For plain codec, timestamp field will be set either as provided by Kafka message (requires Kafka 0.10+),
 or as current time.
 
-For json codec, before fallback to Kafka message timestamp, top-level field "@timestamp" 
-with expected layout `"2006-01-02T15:04:05.000Z"` will be analyzed.
+For json codec, before fallback to Kafka message timestamp, top-level field defined on configuration parameter `timestamp_key` (defaults to `"@timestamp"`)
+with layout defined on configuration parameter `timestamp_layout` (defaults to `"2006-01-02T15:04:05.000Z"`) will be analyzed.
 
 ### Examples
 

--- a/beater/decoder.go
+++ b/beater/decoder.go
@@ -1,0 +1,88 @@
+package beater
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+// Decoder decoder interface
+type decoder interface {
+	Decode(msg *sarama.ConsumerMessage) *beat.Event
+}
+
+type jsonDecoder struct {
+	timestampKey    string
+	timestampLayout string
+	timeNowFn       func() time.Time
+}
+
+// JSON decoder
+func newJSONDecoder(timestampKey, timestampLayout string) *jsonDecoder {
+	return &jsonDecoder{
+		timestampKey:    timestampKey,
+		timestampLayout: timestampLayout,
+		timeNowFn:       time.Now,
+	}
+}
+
+func (d *jsonDecoder) Decode(msg *sarama.ConsumerMessage) *beat.Event {
+	fields := map[string]interface{}{}
+	if err := json.Unmarshal(msg.Value, &fields); err != nil {
+		return nil
+	}
+
+	// special @timestamp field handling
+	var ts time.Time
+	if val, exists := fields[d.timestampKey]; exists {
+		delete(fields, d.timestampKey) // drop timestamp key
+
+		if s, ok := val.(string); ok {
+			if p, err := time.Parse(d.timestampLayout, s); err == nil {
+				ts = time.Time(p)
+			}
+		}
+	}
+
+	if ts.IsZero() {
+		if msg.Timestamp.IsZero() {
+			ts = d.timeNowFn()
+		} else {
+			ts = msg.Timestamp
+		}
+	}
+
+	return &beat.Event{
+		Timestamp: ts,
+		Fields:    fields,
+	}
+}
+
+// Plain decoder
+type plainDecoder struct {
+	timeNowFn func() time.Time
+}
+
+func newPlainDecoder() *plainDecoder {
+	return &plainDecoder{
+		timeNowFn: time.Now,
+	}
+}
+
+func (d *plainDecoder) Decode(msg *sarama.ConsumerMessage) *beat.Event {
+	fields := map[string]interface{}{
+		"message": string(msg.Value),
+	}
+
+	ts := msg.Timestamp
+	if ts.IsZero() {
+		ts = d.timeNowFn()
+	}
+
+	return &beat.Event{
+		Timestamp: ts,
+		Fields:    fields,
+	}
+}

--- a/beater/decoder_test.go
+++ b/beater/decoder_test.go
@@ -1,0 +1,153 @@
+// +build !integration
+
+package beater
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+var (
+	testNowValue = time.Date(1981, time.May, 5, 10, 15, 35, 9583543, time.UTC)
+)
+
+func newTestJSONDecoder() decoder {
+	return &jsonDecoder{
+		timestampKey:    "@timestamp",
+		timestampLayout: common.TsLayout,
+		timeNowFn: func() time.Time {
+			return testNowValue
+		},
+	}
+}
+
+func newTestPlainDecoder() decoder {
+	return &plainDecoder{
+		timeNowFn: func() time.Time {
+			return testNowValue
+		},
+	}
+}
+
+func TestJSONDecoderWithoutTimestamp(t *testing.T) {
+	d := newTestJSONDecoder()
+
+	msg := &sarama.ConsumerMessage{
+		Value: []byte(`{ "field": "value" }`),
+	}
+	e := d.Decode(msg)
+
+	if e == nil {
+		t.Fatal("Event must be generated")
+	}
+	if e.Fields["field"] != "value" {
+		t.Error("Expected field=value keypair, but not found on event")
+	}
+	if e.Timestamp != testNowValue {
+		t.Errorf("Expected %v", testNowValue)
+		t.Errorf("   found %v", e.Timestamp)
+	}
+}
+
+func TestJSONDecoderWithMessageTimestamp(t *testing.T) {
+	ts := time.Date(2019, time.April, 26, 17, 16, 10, 945958000, time.UTC)
+	d := newTestJSONDecoder()
+	msg := &sarama.ConsumerMessage{
+		Value:     []byte(`{ "field": "value" }`),
+		Timestamp: ts,
+	}
+	e := d.Decode(msg)
+
+	if e == nil {
+		t.Fatal("Event must be generated")
+	}
+	if e.Fields["field"] != "value" {
+		t.Error("Expected field=value keypair, but not found on event")
+	}
+	if e.Timestamp != ts {
+		t.Errorf("Expected %v", ts)
+		t.Errorf("   found %v", e.Timestamp)
+	}
+}
+
+func TestJSONDecoderWithValidJSONTimestamp(t *testing.T) {
+	ts := time.Date(2019, time.April, 26, 17, 16, 10, 945000000, time.UTC)
+	d := newTestJSONDecoder()
+	msg := &sarama.ConsumerMessage{
+		Value: []byte(`{ "@timestamp": "2019-04-26T17:16:10.945Z", "field": "value" }`),
+	}
+	e := d.Decode(msg)
+
+	if e == nil {
+		t.Fatal("Event must be generated")
+	}
+	if e.Fields["field"] != "value" {
+		t.Error("Expected field=value keypair, but not found on event")
+	}
+	if e.Timestamp != ts {
+		t.Errorf("Expected %v", ts)
+		t.Errorf("   found %v", e.Timestamp)
+	}
+}
+
+func TestJSONDecoderWithInvalidJSONTimestamp(t *testing.T) {
+	d := newTestJSONDecoder()
+	msg := &sarama.ConsumerMessage{
+		Value: []byte(`{ "@timestamp": "2019-04-26T17:16:10.945759Z", "field": "value" }`),
+	}
+	e := d.Decode(msg)
+
+	if e == nil {
+		t.Fatal("Event must be generated")
+	}
+	if e.Fields["field"] != "value" {
+		t.Error("Expected field=value keypair, but not found on event")
+	}
+	if e.Timestamp != testNowValue {
+		t.Errorf("Expected %v", testNowValue)
+		t.Errorf("   found %v", e.Timestamp)
+	}
+}
+
+func TestPlainDecoderWithoutTimestamp(t *testing.T) {
+	d := newTestPlainDecoder()
+	msg := &sarama.ConsumerMessage{
+		Value: []byte(`mymessage`),
+	}
+	e := d.Decode(msg)
+
+	if e == nil {
+		t.Fatal("Event must be generated")
+	}
+	if e.Fields["message"] != "mymessage" {
+		t.Error("Expected message=mymessage keypair, but not found on event")
+	}
+	if e.Timestamp != testNowValue {
+		t.Errorf("Expected %v", testNowValue)
+		t.Errorf("   found %v", e.Timestamp)
+	}
+}
+
+func TestPlainDecoderWithMessageTimestamp(t *testing.T) {
+	ts := time.Date(2019, time.April, 26, 17, 16, 10, 945958000, time.UTC)
+	d := newTestPlainDecoder()
+	msg := &sarama.ConsumerMessage{
+		Value:     []byte(`mymessage`),
+		Timestamp: ts,
+	}
+	e := d.Decode(msg)
+
+	if e == nil {
+		t.Fatal("Event must be generated")
+	}
+	if e.Fields["message"] != "mymessage" {
+		t.Error("Expected message=mymessage keypair, but not found on event")
+	}
+	if e.Timestamp != ts {
+		t.Errorf("Expected %v", ts)
+		t.Errorf("   found %v", e.Timestamp)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,11 @@
 
 package config
 
-import "runtime"
+import (
+	"runtime"
+
+	"github.com/elastic/beats/libbeat/common"
+)
 
 type Config struct {
 	Brokers           []string `config:"brokers"`
@@ -15,6 +19,8 @@ type Config struct {
 	PublishMode       string   `config:"publish_mode"`
 	ChannelBufferSize int      `config:"channel_buffer_size"`
 	ChannelWorkers    int      `config:"channel_workers"`
+	TimestampKey      string   `config:"timestamp_key"`
+	TimestampLayout   string   `config:"timestamp_layout"`
 }
 
 var DefaultConfig = Config{
@@ -27,4 +33,6 @@ var DefaultConfig = Config{
 	PublishMode:       "default",
 	ChannelBufferSize: 256,
 	ChannelWorkers:    runtime.NumCPU(),
+	TimestampKey:      "@timestamp",
+	TimestampLayout:   common.TsLayout,
 }

--- a/kafkabeat.reference.yml
+++ b/kafkabeat.reference.yml
@@ -25,6 +25,12 @@ kafkabeat:
   # Defaults to "json".
   codec: "json"
 
+  # Timestamp key used by JSON decoder
+  #timestamp_key: "@timestamp"
+
+  # Timestamp layout used by JSON decoder
+  #timestamp_layout: "2006-01-02T15:04:05.000Z"
+
   # Event publish mode: "default", "send" or "drop_if_full".
   # Defaults to "default"
   # @see https://github.com/elastic/beats/blob/v6.3.1/libbeat/beat/pipeline.go#L119

--- a/kafkabeat.yml
+++ b/kafkabeat.yml
@@ -25,6 +25,12 @@ kafkabeat:
   # Defaults to "json".
   codec: "json"
 
+  # Timestamp key used by JSON decoder
+  #timestamp_key: "@timestamp"
+
+  # Timestamp layout used by JSON decoder
+  #timestamp_layout: "2006-01-02T15:04:05.000Z"
+
   # Event publish mode: "default", "send" or "drop_if_full".
   # Defaults to "default"
   # @see https://github.com/elastic/beats/blob/v6.3.1/libbeat/beat/pipeline.go#L119


### PR DESCRIPTION
# Reason
Only timestamp field `@timestamp` with layout `2006-01-02T15:04:05.000Z` is allowed right now. Sometimes this is not the layout present on some events (in our case, the format changes a little bit because we use fluent-bit to send data to kafka and its format is not well recognized as iso8601 because it's `2006-01-02T15:04:05.000000Z' -> 3 more zeroes at the end).

This PR not just allows to specify a different timestamp layout, but also a different timestamp key.

# Changes
* Added two more configuration fields: `timestamp_key` and `timestamp_layout`
* Set previous default values as current default ones (`timestamp_key="@timestamp"` and `timestamp_layout="2006-01-02T15:04:05.000Z"`)
* Moved decoders to a single files and created interface `decoder`, which is used on beater
* Added tests for new `decoder`